### PR TITLE
refactor: consolidate snapshot/screenshot commands into unified snapshot

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -121,17 +121,12 @@ text patterns. This provides reliable detection across different TUI frameworks.
 EXAMPLES:
     agent-tui snapshot              # Just the screen
     agent-tui snapshot -i           # Screen + detected elements
-    agent-tui snapshot -i -c        # Compact element list
     agent-tui snapshot --strip-ansi # Plain text without colors
     agent-tui snapshot -f json      # JSON output for parsing"#)]
     Snapshot {
         /// Include detected interactive elements
         #[arg(short = 'i', long)]
         elements: bool,
-
-        /// Show compact output (remove non-essential elements)
-        #[arg(short = 'c', long)]
-        compact: bool,
 
         /// Scope to a specific region (e.g., "modal", "menu")
         #[arg(long)]
@@ -992,10 +987,9 @@ mod tests {
     /// Test snapshot command flags
     #[test]
     fn test_snapshot_flags() {
-        let cli = Cli::parse_from(["agent-tui", "snapshot", "-i", "-c"]);
+        let cli = Cli::parse_from(["agent-tui", "snapshot", "-i"]);
         let Commands::Snapshot {
             elements,
-            compact,
             region,
             strip_ansi,
             include_cursor,
@@ -1004,7 +998,6 @@ mod tests {
             panic!("Expected Snapshot command, got {:?}", cli.command);
         };
         assert!(elements, "-i should enable elements");
-        assert!(compact, "-c should enable compact");
         assert!(region.is_none());
         assert!(!strip_ansi);
         assert!(!include_cursor);
@@ -1017,7 +1010,6 @@ mod tests {
             "agent-tui",
             "snapshot",
             "-i",
-            "-c",
             "--region",
             "modal",
             "--strip-ansi",
@@ -1025,7 +1017,6 @@ mod tests {
         ]);
         let Commands::Snapshot {
             elements,
-            compact,
             region,
             strip_ansi,
             include_cursor,
@@ -1034,7 +1025,6 @@ mod tests {
             panic!("Expected Snapshot command, got {:?}", cli.command);
         };
         assert!(elements);
-        assert!(compact);
         assert_eq!(region, Some("modal".to_string()));
         assert!(strip_ansi);
         assert!(include_cursor);

--- a/cli/src/daemon/server.rs
+++ b/cli/src/daemon/server.rs
@@ -290,6 +290,12 @@ impl DaemonServer {
 
             "spawn" => self.handle_spawn(request),
             "snapshot" => self.handle_snapshot(request),
+            // Deprecated: Use "snapshot" with strip_ansi=true instead
+            "screen" => Response::error(
+                request.id,
+                -32601,
+                "Method 'screen' is deprecated. Use 'snapshot' with strip_ansi=true instead.",
+            ),
             "click" => self.handle_click(request),
             "dbl_click" => self.handle_dbl_click(request),
             "fill" => self.handle_fill(request),

--- a/cli/src/handlers.rs
+++ b/cli/src/handlers.rs
@@ -272,7 +272,6 @@ pub fn handle_spawn(
 pub fn handle_snapshot(
     ctx: &mut HandlerContext,
     elements: bool,
-    compact: bool,
     region: Option<String>,
     strip_ansi: bool,
     include_cursor: bool,
@@ -280,7 +279,6 @@ pub fn handle_snapshot(
     let params = json!({
         "session": ctx.session,
         "include_elements": elements,
-        "compact": compact,
         "region": region,
         "strip_ansi": strip_ansi,
         "include_cursor": include_cursor

--- a/cli/src/handlers.rs
+++ b/cli/src/handlers.rs
@@ -336,6 +336,8 @@ pub fn handle_snapshot(
                     let visible = cursor.bool_or("visible", false);
                     let vis_str = if visible { "visible" } else { "hidden" };
                     println!("\nCursor: row={}, col={} ({})", row, col, vis_str);
+                } else {
+                    eprintln!("Warning: Cursor position requested but not available from session");
                 }
             }
         }
@@ -391,6 +393,8 @@ pub fn handle_snapshot(
                     let visible = cursor.bool_or("visible", false);
                     let vis_str = if visible { "visible" } else { "hidden" };
                     println!("\nCursor: row={}, col={} ({})", row, col, vis_str);
+                } else {
+                    eprintln!("Warning: Cursor position requested but not available from session");
                 }
             }
         }
@@ -1375,7 +1379,12 @@ pub fn handle_assert(ctx: &mut HandlerContext, condition: String) -> HandlerResu
 
     let passed = match cond_type {
         "text" => {
-            let result = ctx.client.call("snapshot", Some(ctx.session_params()))?;
+            // Strip ANSI codes for consistent text matching
+            let params = json!({
+                "session": ctx.session,
+                "strip_ansi": true
+            });
+            let result = ctx.client.call("snapshot", Some(params))?;
             result.str_or("screen", "").contains(cond_value)
         }
         "element" => {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -87,18 +87,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         } => handlers::handle_spawn(&mut ctx, command, args, cwd, cols, rows)?,
         Commands::Snapshot {
             elements,
-            compact,
             region,
             strip_ansi,
             include_cursor,
-        } => handlers::handle_snapshot(
-            &mut ctx,
-            elements,
-            compact,
-            region,
-            strip_ansi,
-            include_cursor,
-        )?,
+        } => handlers::handle_snapshot(&mut ctx, elements, region, strip_ansi, include_cursor)?,
         Commands::Click { element_ref } => handlers::handle_click(&mut ctx, element_ref)?,
         Commands::DblClick { element_ref } => handlers::handle_dbl_click(&mut ctx, element_ref)?,
         Commands::Fill { element_ref, value } => {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -87,10 +87,18 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         } => handlers::handle_spawn(&mut ctx, command, args, cwd, cols, rows)?,
         Commands::Snapshot {
             elements,
-            interactive_only,
             compact,
             region,
-        } => handlers::handle_snapshot(&mut ctx, elements, interactive_only, compact, region)?,
+            strip_ansi,
+            include_cursor,
+        } => handlers::handle_snapshot(
+            &mut ctx,
+            elements,
+            compact,
+            region,
+            strip_ansi,
+            include_cursor,
+        )?,
         Commands::Click { element_ref } => handlers::handle_click(&mut ctx, element_ref)?,
         Commands::DblClick { element_ref } => handlers::handle_dbl_click(&mut ctx, element_ref)?,
         Commands::Fill { element_ref, value } => {
@@ -105,10 +113,6 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         Commands::Restart => handlers::handle_restart(&mut ctx)?,
         Commands::Sessions => handlers::handle_sessions(&mut ctx)?,
         Commands::Health { verbose } => handlers::handle_health(&mut ctx, verbose)?,
-        Commands::Screenshot {
-            strip_ansi,
-            include_cursor,
-        } => handlers::handle_screenshot(&mut ctx, strip_ansi, include_cursor)?,
         Commands::Resize { cols, rows } => handlers::handle_resize(&mut ctx, cols, rows)?,
         Commands::Version => handlers::handle_version(&mut ctx)?,
         Commands::Cleanup { all } => handlers::handle_cleanup(&mut ctx, all)?,

--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -489,15 +489,11 @@ impl Session {
         let cursor = self.terminal.cursor();
         let components = crate::vom::analyze(&buffer, cursor.row, cursor.col);
 
-        // Filter to interactive elements and convert to Element API
+        // Filter to interactive elements using Role::is_interactive()
+        // This ensures refs (@e1, @e2, etc.) are consistent with handle_snapshot in server.rs
         self.cached_elements = components
             .iter()
-            .filter(|c| {
-                matches!(
-                    c.role,
-                    Role::Button | Role::Tab | Role::Input | Role::Checkbox | Role::MenuItem
-                )
-            })
+            .filter(|c| c.role.is_interactive())
             .enumerate()
             .map(|(i, c)| component_to_element(c, i, cursor.row, cursor.col))
             .collect();

--- a/cli/src/vom/mod.rs
+++ b/cli/src/vom/mod.rs
@@ -135,6 +135,18 @@ pub enum Role {
     MenuItem,
 }
 
+impl Role {
+    /// Returns true if this role represents an interactive element.
+    /// Used by both snapshot (for element listing) and click (for ref indexing)
+    /// to ensure refs (@e1, @e2, etc.) are consistent across commands.
+    pub fn is_interactive(&self) -> bool {
+        matches!(
+            self,
+            Role::Button | Role::Tab | Role::Input | Role::Checkbox | Role::MenuItem
+        )
+    }
+}
+
 impl std::fmt::Display for Role {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/cli/tests/cli_spawn_tests.rs
+++ b/cli/tests/cli_spawn_tests.rs
@@ -67,7 +67,7 @@ fn test_snapshot_help() {
         .success()
         .stdout(predicate::str::contains("snapshot"))
         .stdout(predicate::str::contains("--elements"))
-        .stdout(predicate::str::contains("--compact"));
+        .stdout(predicate::str::contains("--strip-ansi"));
 }
 
 /// Test click command help

--- a/cli/tests/common/mock_daemon.rs
+++ b/cli/tests/common/mock_daemon.rs
@@ -144,6 +144,14 @@ impl MockDaemon {
                     "size": { "cols": super::TEST_COLS, "rows": super::TEST_ROWS }
                 })),
             );
+            // Deprecated method returns error
+            h.insert(
+                "screen".to_string(),
+                MockResponse::Error {
+                    code: -32601,
+                    message: "Method 'screen' is deprecated. Use 'snapshot' with strip_ansi=true instead.".to_string(),
+                },
+            );
             h.insert(
                 "click".to_string(),
                 MockResponse::Success(serde_json::json!({

--- a/cli/tests/common/mock_daemon.rs
+++ b/cli/tests/common/mock_daemon.rs
@@ -145,14 +145,6 @@ impl MockDaemon {
                 })),
             );
             h.insert(
-                "screen".to_string(),
-                MockResponse::Success(serde_json::json!({
-                    "session_id": super::TEST_SESSION_ID,
-                    "screen": "Test screen content\n",
-                    "size": { "cols": super::TEST_COLS, "rows": super::TEST_ROWS }
-                })),
-            );
-            h.insert(
                 "click".to_string(),
                 MockResponse::Success(serde_json::json!({
                     "success": true,

--- a/cli/tests/e2e_daemon_tests.rs
+++ b/cli/tests/e2e_daemon_tests.rs
@@ -398,17 +398,6 @@ fn test_snapshot_json_format() {
 }
 
 #[test]
-fn test_snapshot_compact_mode() {
-    let harness = TestHarness::new();
-
-    harness.run(&["snapshot", "-i", "-c"]).success();
-
-    let request = harness.last_request_for("snapshot").unwrap();
-    let params = request.params.unwrap();
-    assert_eq!(params["compact"], true);
-}
-
-#[test]
 fn test_snapshot_with_elements_uses_vom() {
     let harness = TestHarness::new();
 
@@ -457,18 +446,6 @@ fn test_snapshot_with_elements_uses_vom() {
     let request = harness.last_request_for("snapshot").unwrap();
     let params = request.params.unwrap();
     assert_eq!(params["include_elements"], true);
-}
-
-#[test]
-fn test_snapshot_with_compact_elements() {
-    let harness = TestHarness::new();
-
-    harness.run(&["snapshot", "-i", "-c"]).success();
-
-    let request = harness.last_request_for("snapshot").unwrap();
-    let params = request.params.unwrap();
-    assert_eq!(params["include_elements"], true);
-    assert_eq!(params["compact"], true);
 }
 
 // =============================================================================
@@ -748,7 +725,6 @@ fn test_snapshot_all_flags_e2e() {
         .run(&[
             "snapshot",
             "-i",
-            "-c",
             "--region",
             "modal",
             "--strip-ansi",
@@ -759,7 +735,6 @@ fn test_snapshot_all_flags_e2e() {
     let request = harness.last_request_for("snapshot").unwrap();
     let params = request.params.unwrap();
     assert_eq!(params["include_elements"], true);
-    assert_eq!(params["compact"], true);
     assert_eq!(params["region"], "modal");
     assert_eq!(params["strip_ansi"], true);
     assert_eq!(params["include_cursor"], true);

--- a/docs/commands/snapshot.mdx
+++ b/docs/commands/snapshot.mdx
@@ -18,8 +18,9 @@ Captures the current screen content of the active TUI session. With `-i`, also d
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-i, --interactive` | Detect interactive elements | false |
-| `-c, --compact` | Compact output (less whitespace) | false |
-| `--interactive-only` | Show only elements, no screen | false |
+| `--strip-ansi` | Remove ANSI escape codes (plain text) | false |
+| `--include-cursor` | Include cursor position in output | false |
+| `--region <name>` | Scope to a specific region | none |
 | `-f, --format <fmt>` | Output format: `text` or `json` | text |
 
 ## Examples
@@ -37,14 +38,14 @@ agent-tui snapshot -i
 ### Output Formats
 
 ```bash
-# Compact for less noise
-agent-tui snapshot -i -c
+# Plain text without ANSI colors
+agent-tui snapshot --strip-ansi
 
 # JSON for parsing
 agent-tui snapshot -i -f json | jq '.elements'
 
-# Only elements, no screen
-agent-tui snapshot -i --interactive-only
+# Include cursor position
+agent-tui snapshot --include-cursor
 ```
 
 ## Output

--- a/docs/specs/04-SNAPSHOT.spec.md
+++ b/docs/specs/04-SNAPSHOT.spec.md
@@ -44,7 +44,6 @@ pub struct SnapshotParams {
     pub session: Option<String>,
     pub include_elements: Option<bool>,   // Include detected elements
     pub format: Option<SnapshotFormat>,   // text | json | tree
-    pub compact: Option<bool>,            // Compact output (hide static text)
     pub region: Option<String>,           // Scope to region
     pub strip_ansi: Option<bool>,         // Remove ANSI escape codes
     pub include_cursor: Option<bool>,     // Include cursor position
@@ -86,7 +85,6 @@ agent-browser snapshot --interactive --compact
 # TUI
 agent-tui snapshot              # Screen only (most common)
 agent-tui snapshot -i           # Screen + detected elements
-agent-tui snapshot -i -c        # Compact element list
 agent-tui snapshot --strip-ansi # Plain text without colors
 agent-tui snapshot -i -f json   # JSON with elements
 agent-tui snapshot --include-cursor  # Include cursor position
@@ -121,8 +119,7 @@ agent-tui snapshot --include-cursor  # Include cursor position
   "jsonrpc": "2.0",
   "method": "snapshot",
   "params": {
-    "include_elements": true,
-    "compact": true
+    "include_elements": true
   },
   "id": 2
 }

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -19,7 +19,7 @@ This directory contains specifications mapping agent-browser commands to their T
 | [01-SESSION_LIFECYCLE.spec.md](01-SESSION_LIFECYCLE.spec.md) | Session Lifecycle | spawn, kill, sessions, health |
 | [02-NAVIGATION.spec.md](02-NAVIGATION.spec.md) | Navigation | N/A for TUI (browser URLs) |
 | [03-ELEMENT_INTERACTION.spec.md](03-ELEMENT_INTERACTION.spec.md) | Element Interaction | click, fill, type, focus, clear |
-| [04-SNAPSHOT.spec.md](04-SNAPSHOT.spec.md) | Snapshot | snapshot, screen |
+| [04-SNAPSHOT.spec.md](04-SNAPSHOT.spec.md) | Snapshot | snapshot |
 | [05-KEYBOARD_MOUSE.spec.md](05-KEYBOARD_MOUSE.spec.md) | Keyboard & Mouse | keystroke, scroll |
 | [06-WAITING.spec.md](06-WAITING.spec.md) | Waiting | wait, waitfor* |
 | [07-STATE_QUERY.spec.md](07-STATE_QUERY.spec.md) | State Query | get_text, is_visible |
@@ -52,7 +52,7 @@ This directory contains specifications mapping agent-browser commands to their T
 | press | keystroke | ✅ Exists |
 | clear | clear | ✅ Exists |
 | snapshot | snapshot | ✅ Exists |
-| screenshot | screen | ✅ Exists |
+| screenshot | snapshot --strip-ansi | ✅ Exists |
 | keyboard | keystroke | ✅ Exists |
 | scroll | scroll | ✅ Exists |
 | wait | wait | ✅ Exists |

--- a/skills/agent-tui/SKILL.md
+++ b/skills/agent-tui/SKILL.md
@@ -47,8 +47,8 @@ agent-tui keystroke Enter               # Confirm
 | `snapshot` | Capture screen text | `agent-tui snapshot` |
 | `snapshot -i` | Capture screen + detect elements | `agent-tui snapshot -i` |
 | `snapshot -i -c` | Compact view (less noise) | `agent-tui snapshot -i -c` |
-| `snapshot -i --interactive-only` | Only actionable elements | `agent-tui snapshot -i --interactive-only` |
-| `screen` | Raw screen text only | `agent-tui screen` |
+| `snapshot --strip-ansi` | Plain text without colors | `agent-tui snapshot --strip-ansi` |
+| `snapshot --include-cursor` | Include cursor position | `agent-tui snapshot --include-cursor` |
 
 ### Interactions (use @refs from snapshot)
 

--- a/skills/agent-tui/SKILL.md
+++ b/skills/agent-tui/SKILL.md
@@ -46,7 +46,6 @@ agent-tui keystroke Enter               # Confirm
 |---------|-------------|---------|
 | `snapshot` | Capture screen text | `agent-tui snapshot` |
 | `snapshot -i` | Capture screen + detect elements | `agent-tui snapshot -i` |
-| `snapshot -i -c` | Compact view (less noise) | `agent-tui snapshot -i -c` |
 | `snapshot --strip-ansi` | Plain text without colors | `agent-tui snapshot --strip-ansi` |
 | `snapshot --include-cursor` | Include cursor position | `agent-tui snapshot --include-cursor` |
 


### PR DESCRIPTION
## Summary
- Remove the separate `screenshot` command and `screen` RPC method, consolidating all screen capture functionality into the unified `snapshot` command
- Add `--strip-ansi` flag to snapshot (replaces screenshot's primary use case)
- Add `--include-cursor` flag to snapshot for explicit cursor position output
- Remove `--interactive-only` flag (use `-c`/`--compact` instead for filtering static text)
- Update assert command to use snapshot instead of screen internally

## Test plan
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` - all 268 tests pass
- [x] `agent-tui snapshot --help` shows new flags
- [x] `agent-tui screenshot` returns "command not found"
- [x] `agent-tui snapshot --interactive-only` returns "flag not found"