### PR TITLE
refactor: simplify CLI code with extractions and remove Tree format

### DIFF
--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -110,15 +110,6 @@ impl DaemonClient {
 
         response.result.ok_or(ClientError::InvalidResponse)
     }
-
-    #[allow(dead_code)]
-    pub fn ping(&mut self) -> Result<bool, ClientError> {
-        let result = self.call("ping", None)?;
-        Ok(result
-            .get("pong")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false))
-    }
 }
 
 pub fn start_daemon_background() -> Result<(), ClientError> {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -810,6 +810,7 @@ impl std::fmt::Display for WaitConditionArg {
 
 /// Parameters for the wait command
 #[derive(Debug, Clone, Default, Parser)]
+#[command(group = clap::ArgGroup::new("wait_condition").multiple(false).args(&["element", "visible", "focused", "not_visible", "text_gone", "stable", "value"]))]
 pub struct WaitParams {
     /// Text to wait for (legacy mode, use --condition for more options)
     pub text: Option<String>,
@@ -819,7 +820,7 @@ pub struct WaitParams {
     pub timeout: u64,
 
     /// Wait condition type
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, conflicts_with = "wait_condition")]
     pub condition: Option<WaitConditionArg>,
 
     /// Target for the condition (element ref or text pattern)
@@ -827,31 +828,31 @@ pub struct WaitParams {
     pub target: Option<String>,
 
     /// Wait for element to appear
-    #[arg(long, conflicts_with_all = ["condition", "text", "visible"])]
+    #[arg(long, group = "wait_condition")]
     pub element: Option<String>,
 
     /// Wait for element to appear (alias for --element, agent-browser parity)
-    #[arg(long, conflicts_with_all = ["condition", "text", "element"])]
+    #[arg(long, group = "wait_condition")]
     pub visible: Option<String>,
 
     /// Wait for element to be focused
-    #[arg(long, conflicts_with_all = ["condition", "text", "element", "visible"])]
+    #[arg(long, group = "wait_condition")]
     pub focused: Option<String>,
 
     /// Wait for element to disappear
-    #[arg(long, conflicts_with_all = ["condition", "text", "element", "visible", "focused"])]
+    #[arg(long, group = "wait_condition")]
     pub not_visible: Option<String>,
 
     /// Wait for text to disappear
-    #[arg(long, conflicts_with_all = ["condition", "text", "element", "visible", "focused", "not_visible"])]
+    #[arg(long, group = "wait_condition")]
     pub text_gone: Option<String>,
 
     /// Wait for screen to stabilize
-    #[arg(long, conflicts_with_all = ["condition", "text", "element", "visible", "focused", "not_visible", "text_gone", "value"])]
+    #[arg(long, group = "wait_condition")]
     pub stable: bool,
 
     /// Wait for input to have specific value (format: @ref=value)
-    #[arg(long, conflicts_with_all = ["condition", "text", "element", "visible", "focused", "not_visible", "text_gone", "stable"])]
+    #[arg(long, group = "wait_condition")]
     pub value: Option<String>,
 }
 
@@ -892,8 +893,6 @@ pub enum OutputFormat {
     #[default]
     Text,
     Json,
-    /// Accessibility-tree format (agent-browser style): "- button "Submit" [ref=@btn1]"
-    Tree,
 }
 
 #[cfg(test)]
@@ -1374,13 +1373,6 @@ mod tests {
     fn test_json_shorthand_flag() {
         let cli = Cli::parse_from(["agent-tui", "--json", "health"]);
         assert!(cli.json);
-    }
-
-    /// Test tree output format
-    #[test]
-    fn test_tree_output_format() {
-        let cli = Cli::parse_from(["agent-tui", "-f", "tree", "snapshot"]);
-        assert_eq!(cli.format, OutputFormat::Tree);
     }
 
     /// Test spawn with cwd argument

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -775,12 +775,32 @@ pub enum RecordFormat {
     Asciicast,
 }
 
+impl RecordFormat {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RecordFormat::Json => "json",
+            RecordFormat::Asciicast => "asciicast",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, ValueEnum)]
 pub enum ScrollDirection {
     Up,
     Down,
     Left,
     Right,
+}
+
+impl ScrollDirection {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ScrollDirection::Up => "up",
+            ScrollDirection::Down => "down",
+            ScrollDirection::Left => "left",
+            ScrollDirection::Right => "right",
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -856,6 +856,34 @@ pub struct WaitParams {
     pub value: Option<String>,
 }
 
+impl WaitParams {
+    /// Resolve wait condition from WaitParams to (condition_type, target) tuple
+    pub fn resolve_condition(&self) -> (Option<String>, Option<String>) {
+        if self.stable {
+            return (Some("stable".to_string()), None);
+        }
+
+        let checks: &[(&str, Option<&String>)] = &[
+            ("element", self.element.as_ref()),
+            ("element", self.visible.as_ref()),
+            ("focused", self.focused.as_ref()),
+            ("not_visible", self.not_visible.as_ref()),
+            ("text_gone", self.text_gone.as_ref()),
+            ("value", self.value.as_ref()),
+        ];
+
+        for (cond, target) in checks {
+            if let Some(t) = target {
+                return (Some((*cond).to_string()), Some((*t).clone()));
+            }
+        }
+
+        self.condition
+            .map(|c| (Some(c.to_string()), self.target.clone()))
+            .unwrap_or((None, None))
+    }
+}
+
 /// Parameters for the find command
 #[derive(Debug, Clone, Default, Parser)]
 pub struct FindParams {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -73,6 +73,17 @@ pub struct Cli {
     pub debug: bool,
 }
 
+impl Cli {
+    /// Returns the effective output format, considering --json shorthand.
+    pub fn effective_format(&self) -> OutputFormat {
+        if self.json {
+            OutputFormat::Json
+        } else {
+            self.format
+        }
+    }
+}
+
 #[derive(Debug, Subcommand)]
 pub enum Commands {
     /// Spawn a new TUI application in a virtual terminal

--- a/cli/src/daemon/ansi_keys.rs
+++ b/cli/src/daemon/ansi_keys.rs
@@ -1,0 +1,6 @@
+//! ANSI escape sequences for cursor/arrow keys.
+
+pub const UP: &[u8] = b"\x1b[A";
+pub const DOWN: &[u8] = b"\x1b[B";
+pub const RIGHT: &[u8] = b"\x1b[C";
+pub const LEFT: &[u8] = b"\x1b[D";

--- a/cli/src/daemon/mod.rs
+++ b/cli/src/daemon/mod.rs
@@ -1,3 +1,4 @@
+mod ansi_keys;
 mod error_messages;
 mod lock_helpers;
 mod rpc_types;

--- a/cli/src/daemon/select_helpers.rs
+++ b/cli/src/daemon/select_helpers.rs
@@ -1,9 +1,7 @@
+use super::ansi_keys;
 use crate::session::Session;
 use std::thread;
 use std::time::Duration;
-
-const ARROW_UP: &[u8] = b"\x1b[A";
-const ARROW_DOWN: &[u8] = b"\x1b[B";
 
 pub fn navigate_to_option(
     sess: &mut Session,
@@ -19,7 +17,11 @@ pub fn navigate_to_option(
         .unwrap_or(0);
 
     let steps = target_idx as i32 - current_idx as i32;
-    let key = if steps > 0 { ARROW_DOWN } else { ARROW_UP };
+    let key = if steps > 0 {
+        ansi_keys::DOWN
+    } else {
+        ansi_keys::UP
+    };
 
     for _ in 0..steps.unsigned_abs() {
         sess.pty_write(key)?;

--- a/cli/src/handlers.rs
+++ b/cli/src/handlers.rs
@@ -755,17 +755,10 @@ pub fn handle_multiselect(
         }
         OutputFormat::Text => {
             if result.bool_or("success", false) {
-                let selected = result
-                    .get("selected_options")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str())
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    })
-                    .unwrap_or_default();
-                println!("Selected: {}", selected);
+                println!(
+                    "Selected: {}",
+                    result.str_array_join("selected_options", ", ")
+                );
             } else {
                 eprintln!(
                     "Multiselect failed: {}",

--- a/cli/src/json_ext.rs
+++ b/cli/src/json_ext.rs
@@ -12,6 +12,9 @@ pub trait ValueExt {
 
     /// Get a bool field or return default.
     fn bool_or(&self, key: &str, default: bool) -> bool;
+
+    /// Get an array field's string elements joined by a separator.
+    fn str_array_join(&self, key: &str, sep: &str) -> String;
 }
 
 impl ValueExt for Value {
@@ -25,5 +28,17 @@ impl ValueExt for Value {
 
     fn bool_or(&self, key: &str, default: bool) -> bool {
         self.get(key).and_then(|v| v.as_bool()).unwrap_or(default)
+    }
+
+    fn str_array_join(&self, key: &str, sep: &str) -> String {
+        self.get(key)
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str())
+                    .collect::<Vec<_>>()
+                    .join(sep)
+            })
+            .unwrap_or_default()
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -64,18 +64,12 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    let format = if cli.json {
-        commands::OutputFormat::Json
-    } else {
-        cli.format
-    };
-
+    let format = cli.effective_format();
     let mut ctx = HandlerContext::new(&mut client, cli.session, format);
 
     match cli.command {
-        Commands::Daemon => unreachable!(),
-        Commands::DemoRun => unreachable!(),
-        Commands::Completions { .. } => unreachable!(),
+        // Handled above before client initialization
+        Commands::Daemon | Commands::DemoRun | Commands::Completions { .. } => unreachable!(),
 
         Commands::Demo => handlers::handle_demo(&mut ctx)?,
         Commands::Spawn {

--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -144,6 +144,19 @@ fn role_to_element_type(role: Role) -> ElementType {
     }
 }
 
+/// Infer checked state from checkbox text patterns
+fn infer_checked_state(text: &str) -> Option<bool> {
+    let lower = text.to_lowercase();
+    if lower.contains("[x]") || lower.contains("(x)") || lower.contains("☑") || lower.contains("✓")
+    {
+        Some(true)
+    } else if lower.contains("[ ]") || lower.contains("( )") || lower.contains("☐") {
+        Some(false)
+    } else {
+        None
+    }
+}
+
 /// Convert a VOM Component to an Element for API compatibility
 fn component_to_element(
     comp: &Component,
@@ -153,17 +166,8 @@ fn component_to_element(
 ) -> Element {
     let focused = comp.bounds.contains(cursor_col, cursor_row);
 
-    // Infer checked state for checkboxes from text patterns
     let checked = if comp.role == Role::Checkbox {
-        let text = comp.text_content.to_lowercase();
-        if text.contains("[x]") || text.contains("(x)") || text.contains("☑") || text.contains("✓")
-        {
-            Some(true)
-        } else if text.contains("[ ]") || text.contains("( )") || text.contains("☐") {
-            Some(false)
-        } else {
-            None
-        }
+        infer_checked_state(&comp.text_content)
     } else {
         None
     };

--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -1026,6 +1026,19 @@ pub struct SessionInfo {
     pub size: (u16, u16),
 }
 
+impl SessionInfo {
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "id": self.id,
+            "command": self.command,
+            "pid": self.pid,
+            "running": self.running,
+            "created_at": self.created_at,
+            "size": { "cols": self.size.0, "rows": self.size.1 }
+        })
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PersistedSession {
     pub id: SessionId,

--- a/cli/src/wait.rs
+++ b/cli/src/wait.rs
@@ -58,6 +58,24 @@ impl WaitCondition {
             }
         }
     }
+
+    pub fn matched_text(&self) -> Option<String> {
+        match self {
+            WaitCondition::Text(t) | WaitCondition::TextGone(t) => Some(t.clone()),
+            WaitCondition::Value { expected, .. } => Some(expected.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn element_ref(&self) -> Option<String> {
+        match self {
+            WaitCondition::Element(e)
+            | WaitCondition::Focused(e)
+            | WaitCondition::NotVisible(e) => Some(e.clone()),
+            WaitCondition::Value { element, .. } => Some(element.clone()),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Default)]


### PR DESCRIPTION
## Summary
- Remove `OutputFormat::Tree` variant and ~50 lines of Tree-specific rendering code
- Extract `resolve_wait_condition()` helper function from `handle_wait`
- Extract `filter_interactive_components()` helper from `handle_snapshot` in server.rs
- Extract `infer_checked_state()` helper from `component_to_element` in session.rs
- Replace repetitive `conflicts_with_all` attributes with clap `ArgGroup` for `WaitParams`
- Remove dead `checked()` method from `ElementView` and associated tests

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo lint` passes with no warnings
- [x] `cargo test --lib` - 65/65 tests pass
- [x] `cargo test --bin agent-tui` - 227/227 tests pass
- [x] Manual verification: `agent-tui --help` works correctly