### PR TITLE
fix: wire terminal query responses (DSR/CPR) back to child PTY

### DIFF
--- a/cli/crates/agent-tui-infra/src/infra/daemon/pty_session.rs
+++ b/cli/crates/agent-tui-infra/src/infra/daemon/pty_session.rs
@@ -15,6 +15,12 @@ impl PtySession {
         Self { handle }
     }
 
+    pub fn writer_handle(
+        &self,
+    ) -> std::sync::Arc<std::sync::Mutex<Box<dyn std::io::Write + Send>>> {
+        self.handle.writer_handle()
+    }
+
     pub fn pid(&self) -> Option<u32> {
         self.handle.pid()
     }

--- a/cli/crates/agent-tui-infra/src/infra/daemon/terminal_state.rs
+++ b/cli/crates/agent-tui-infra/src/infra/daemon/terminal_state.rs
@@ -9,9 +9,9 @@ pub struct TerminalState {
 }
 
 impl TerminalState {
-    pub fn new(cols: u16, rows: u16) -> Self {
+    pub fn new(cols: u16, rows: u16, writer: Box<dyn std::io::Write + Send>) -> Self {
         Self {
-            terminal: VirtualTerminal::new(cols, rows),
+            terminal: VirtualTerminal::new(cols, rows, writer),
         }
     }
 

--- a/cli/crates/agent-tui-infra/src/infra/terminal/pty.rs
+++ b/cli/crates/agent-tui-infra/src/infra/terminal/pty.rs
@@ -141,6 +141,12 @@ impl PtyHandle {
             .unwrap_or(false)
     }
 
+    /// Returns a clone of the PTY writer handle for feeding terminal responses
+    /// (e.g. DSR/CPR) back to the child process.
+    pub fn writer_handle(&self) -> Arc<Mutex<Box<dyn Write + Send>>> {
+        Arc::clone(&self.writer)
+    }
+
     pub fn write(&self, data: &[u8]) -> Result<(), PtyError> {
         if data.is_empty() {
             return Ok(());


### PR DESCRIPTION
## Summary

- The virtual terminal used `io::sink()` as the wezterm writer, silently discarding all terminal-to-application responses (DSR/CPR, DA1, etc.)
- This broke TUI apps that query cursor position — notably ratatui's `Viewport::Inline` mode, which sends `\x1b[6n` on init and expects a CPR response
- Wires the PTY master writer into `VirtualTerminal` via an `ArcWriter` adapter so wezterm's responses flow back to the child process

## Changes

- `pty.rs`: Add `writer_handle()` to expose a clone of the `Arc<Mutex<...>>` PTY writer
- `pty_session.rs`: Pass through `writer_handle()`
- `vterm.rs`: Accept a `Box<dyn Write + Send>` writer parameter instead of using `io::sink()`
- `terminal_state.rs`: Forward the writer to `VirtualTerminal`
- `session.rs`: Add `ArcWriter` adapter struct; wire PTY writer into `VirtualTerminal` during session creation

## Test plan

- [x] `just ready` passes (fmt, clippy, architecture, 451 tests, version check)
- [x] New `test_dsr_cursor_position_response` unit test verifies CPR flows through the writer
- [x] E2E: Python raw-mode test confirms `\x1b[1;1R` arrives on child stdin
- [x] E2E: ratatui `Viewport::Inline` TUI app renders correctly under agent-tui (previously failed)